### PR TITLE
functionName can now handle nesting inside method:

### DIFF
--- a/src/test/scala/io/FunctionMetaTest.scala
+++ b/src/test/scala/io/FunctionMetaTest.scala
@@ -88,6 +88,15 @@ class FunctionMetaTest extends WordSpec with Matchers {
 
       method(List("hello", "yesterday"), 1100, Foo(12.3))
     }
+    "return name of the function when assigned to a val" in {
+      def method(): Unit = {
+        val funcName = functionName
+
+        funcName shouldBe "method"
+        ()
+      }
+      method()
+    }
     "not compile outside function" in {
 
       illTyped(


### PR DESCRIPTION
If functionName is assigned to a val, the enclosing owner is not a
method. To find the enclosing method, recursively walk the Symbol owner
hierarchy.